### PR TITLE
Simplified TAU builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,23 +139,19 @@ endif(${ODE_SOLVER} STREQUAL "RK_suite")
 
 # Optionally turn on performance monitoring with TAU on AIX
 # if ${TAU_MAKEFILE} is set
-if (${CMAKE_SYSTEM_NAME} STREQUAL "AIX" AND (NOT "${TAU_MAKEFILE}" STREQUAL ""))
-        get_filename_component(TAU_LIBRARY_DIR "${TAU_MAKEFILE}" DIRECTORY)
+if (${CMAKE_SYSTEM_NAME} STREQUAL "AIX" AND (NOT "$ENV{TAU_MAKEFILE}" STREQUAL ""))
+        get_filename_component(TAU_LIBRARY_DIR "$ENV{TAU_MAKEFILE}" DIRECTORY)
         get_filename_component(TAU_DIR "${TAU_LIBRARY_DIR}" DIRECTORY)
-        set(ENV{TAU_MAKEFILE} "${TAU_MAKEFILE}")
-        set(ENV{PATH} "${TAU_DIR}/bin:$ENV{PATH}")
         message(STATUS "**********************************************************")
-        message(STATUS "Please set the follwing prior to typing 'make':")
-        message(STATUS "export PATH=${TAU_DIR}/bin:$PATH")
-        message(STATUS "export TAU_MAKEFILE=$ENV{TAU_MAKEFILE}")
+        message(STATUS "Will use TAU compilers:")
         message(STATUS "**********************************************************")
-        set(CMAKE_C_COMPILER "tau_cc.sh")
+        set(CMAKE_C_COMPILER "taucc")
         set(CMAKE_C_FLAGS 
             "-optVerbose -O2 -qstrict -qmaxmem=-1 -qarch=pwr6 -qtune=pwr6")
-        set(CMAKE_CXX_COMPILER "tau_cxx.sh")
+        set(CMAKE_CXX_COMPILER "taucxx")
         set(CMAKE_CXX_FLAGS 
             "-optVerbose -O3 -qstrict -qmaxmem=-1 -qarch=pwr6 -qtune=pwr6 -qreport -qhot -qsimd")
-        set(CMAKE_Fortran_COMPILER "tau_f90.sh") 
+        set(CMAKE_Fortran_COMPILER "tauf90") 
         set(CMAKE_Fortran_FLAGS 
             "-optVerbose ${CMAKE_Fortran_FLAGS} -qstrict -qfixed -O2 -qmaxmem=-1 -qarch=pwr6 -qtune=pwr6")
     

--- a/README.md
+++ b/README.md
@@ -88,18 +88,18 @@ Compiling with TAU instrumentation enabled
 ------------------------------------------
 
 On platforms that have the Tuning and Analysis Utilities (TAU) installed, it is possible 
-to compile with the TAU compilers by setting the TAU_MAKEFILE variable to point to the 
+to compile with the TAU compilers by setting the environment variable TAU_MAKEFILE to point to the 
 location of the TAU Makefile to be used. 
 
 For instance on Fitzroy:
 
 ```bash
 module load tau
-cmake -DTAU_MAKEFILE=$TAU_MAKEFILE [options] <src_dir>
+cmake [options] <src_dir>
 ```
 
 The "module load tau" command will set the environment variable TAU_MAKEFILE. 
-Make sure to have the TAU compilers (tau_cxx.sh) in your PATH.
+Make sure to have the TAU compilers (taucxx) in your PATH.
 
 
 Then type "make" and run the code normally as indicated below. The executable will 


### PR DESCRIPTION
@c-zakkaroff It is no longer necessary to pass -DTAU_MAKEFILE to build with TAU, it suffices to have the TAU_MAKEFILE variable set on AIX. 